### PR TITLE
JSHint static analysis implementation

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -160,6 +160,7 @@
         "eslint": "8.57.0",
         "eslint-config-nodebb": "0.2.1",
         "eslint-plugin-import": "2.29.1",
+        "jshint":"2.13.6",
         "grunt": "1.6.1",
         "grunt-contrib-watch": "1.1.0",
         "husky": "8.0.3",

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = {
+    reporter: function (errors) {
+      console.log(errors.length ? "FAIL" : "OK");
+    }
+  };
+  


### PR DESCRIPTION
- Added JSHint ver 2.13.6 in the package dependencies install/package.json
- Added JSHint reporting tool for code pass/fail in test/reporter.js
- JSHint is run primarily in CLI with jshint command: `jshint <filepath> --verbose`
- Use `jshint --reporter <filepath>` to run the reporter file

<img width="901" alt="Screenshot 2025-03-13 at 3 55 57 PM" src="https://github.com/user-attachments/assets/9a3b31de-861e-4293-993a-35660d6f7f40" />