### PR TITLE
Plato CI Deployment

### DIFF
--- a/.github/workflows/VM-deploy.yml
+++ b/.github/workflows/VM-deploy.yml
@@ -37,4 +37,4 @@ jobs:
             docker compose --profile redis up --build -d
             npm run static
             cd report
-            nohup http-server > /dev/null >2&1
+            nohup http-server > server.log 2>&1 < /dev/null &

--- a/.github/workflows/VM-deploy.yml
+++ b/.github/workflows/VM-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - test-plato-deployment
   workflow_dispatch:
     
 concurrency:
@@ -34,3 +35,6 @@ jobs:
             git pull origin main
             docker compose down
             docker compose --profile redis up --build -d
+            npm run static
+            cd report
+            nohup http-server > /dev/null >2&1

--- a/.github/workflows/VM-deploy.yml
+++ b/.github/workflows/VM-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - test-plato-deployment
   workflow_dispatch:
     
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ test.sh
 /nodebb-plugin-quickstart
 
 *.rdb
+report

--- a/install/package.json
+++ b/install/package.json
@@ -12,6 +12,7 @@
     "scripts": {
         "start": "node loader.js",
         "lint": "eslint --cache ./nodebb .",
+        "static": "plato -r -d report -e .eslintrc -t 'NodeBB SPEEE' -x .json */*.js",
         "test": "nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
@@ -35,6 +36,7 @@
         "@isaacs/ttlcache": "1.4.1",
         "@nodebb/spider-detector": "2.0.3",
         "@popperjs/core": "2.11.8",
+        "@socket.io/redis-adapter": "8.3.0",
         "ace-builds": "1.33.2",
         "archiver": "7.0.1",
         "async": "3.2.5",
@@ -75,6 +77,7 @@
         "helmet": "7.1.0",
         "html-to-text": "9.0.5",
         "imagesloaded": "5.0.0",
+        "ioredis": "5.4.1",
         "ipaddr.js": "2.2.0",
         "jquery": "3.7.1",
         "jquery-deserialize": "2.0.0",
@@ -99,6 +102,7 @@
         "nodebb-plugin-dbsearch": "6.2.5",
         "nodebb-plugin-emoji": "5.1.15",
         "nodebb-plugin-emoji-android": "4.0.0",
+        "nodebb-plugin-location-to-map": "^0.1.1",
         "nodebb-plugin-markdown": "12.2.6",
         "nodebb-plugin-mentions": "4.4.3",
         "nodebb-plugin-ntfy": "1.7.4",
@@ -120,7 +124,6 @@
         "postcss-clean": "1.2.0",
         "progress-webpack-plugin": "1.0.16",
         "prompt": "1.3.0",
-        "ioredis": "5.4.1",
         "rimraf": "5.0.7",
         "rss": "1.2.2",
         "rtlcss": "4.1.1",
@@ -132,7 +135,6 @@
         "sitemap": "7.1.1",
         "socket.io": "4.7.5",
         "socket.io-client": "4.7.5",
-        "@socket.io/redis-adapter": "8.3.0",
         "sortablejs": "1.15.2",
         "spdx-license-list": "6.9.0",
         "terser-webpack-plugin": "5.3.10",
@@ -169,6 +171,7 @@
         "mocha-lcov-reporter": "1.3.0",
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
+        "plato": "^1.7.0",
         "smtp-server": "3.13.4"
     },
     "optionalDependencies": {


### PR DESCRIPTION
On pushing to main, the static files in `/report` are served to our cloud machine at the `:8080` port, using [`http-server`](https://www.npmjs.com/package/http-server). This is deployed via the [VM-deploy YAML](https://github.com/CMU-313/nodebb-s25-speee/blob/main/.github/workflows/VM-deploy.yml) file, which now additionally runs the Plato dynamic analyzer on push, then runs the HTTP server on `/report`.

The deployment is available here: [http://17313-team13.s3d.cmu.edu:8080/](http://17313-team13.s3d.cmu.edu:8080/)